### PR TITLE
Update Bcrypt.php

### DIFF
--- a/src/YiiPassword/Strategies/Bcrypt.php
+++ b/src/YiiPassword/Strategies/Bcrypt.php
@@ -51,7 +51,7 @@ class Bcrypt extends Strategy
 		}
 
 		if (strlen($bytes) < $count) {
-			$key = uniqid(Yii::app()->name, true);
+			$key = uniqid(\Yii::app()->name, true);
 
 			// we need to pad with some pseudo random bytes
 			while(strlen($bytes) < $count) {


### PR DESCRIPTION
Put "\" in front of Yii to make sure the autoload takes it from the base name space rather than what define in the file.

I used PHP 5.3.5. May be in other version of PHP doesn't have this problem? I'm not sure about this.
